### PR TITLE
Issue 9/task/email address spec

### DIFF
--- a/initialize_db_script.py
+++ b/initialize_db_script.py
@@ -65,6 +65,14 @@ SQL_STATEMENT = """INSERT INTO assignments VALUES(
 
 c.execute(SQL_STATEMENT)
 
+SQL_STATEMENT = """CREATE TABLE IF NOT EXISTS email_address (
+                        author_id    INT,
+                        email_id       VARCHAR(50),
+                        is_active   BOOLEAN NOT NULL CHECK (is_active IN (0, 1))
+                    );"""
+
+c.execute(SQL_STATEMENT)
+
 SQL_STATEMENT = """INSERT INTO assignments VALUES(
                         1,
                         "Assignment #2",

--- a/src/bot.py
+++ b/src/bot.py
@@ -101,6 +101,13 @@ async def on_ready():
         )
     ''')
 
+    db.mutation_query('''
+        CREATE TABLE IF NOT EXISTS email_address (
+            author_id    INT,
+            email_id       VARCHAR(50),
+            is_active   BOOLEAN NOT NULL CHECK (is_active IN (0, 1))
+        )
+    ''')
 
     event_creation.init(bot)
     office_hours.init(bot)

--- a/src/bot.py
+++ b/src/bot.py
@@ -543,9 +543,11 @@ async def update_email(ctx, email_id):
 async def view_email(ctx):
     await email_address.view_email(ctx)
 
-# @bot.command(name='remove_email', help='deletes the configured email address against user.')
-# async def create_email(ctx):
-#     await
+
+@bot.command(name='remove_email', help='deletes the configured email address against user.')
+async def delete_email(ctx):
+    await email_address.delete_email(ctx)
+
 ###########################
 # Function: help
 # Description: Describes the help

--- a/src/bot.py
+++ b/src/bot.py
@@ -23,6 +23,7 @@ import db
 import profanity
 import event_creation
 import office_hours
+import email_address
 import cal
 import qna
 import attendance
@@ -527,6 +528,24 @@ async def custom_profanity(ctx, pword):
 async def attend(ctx):
     await attendance.compute(bot, ctx)
 
+
+@bot.command(name='create_email', help='Configures the specified email address against user.')
+async def create_email(ctx, email_id):
+    await email_address.create_email(ctx, email_id)
+
+
+@bot.command(name='update_email', help='Updates the configured email address against user.')
+async def update_email(ctx, email_id):
+    await email_address.update_email(ctx, email_id)
+
+
+@bot.command(name='view_email', help='displays the configured email address against user.')
+async def view_email(ctx):
+    await email_address.view_email(ctx)
+
+# @bot.command(name='remove_email', help='deletes the configured email address against user.')
+# async def create_email(ctx):
+#     await
 ###########################
 # Function: help
 # Description: Describes the help

--- a/src/email_address.py
+++ b/src/email_address.py
@@ -1,7 +1,22 @@
+"""
+This file contains functions and logic related to email address configuration.
+"""
 import db
 
 
 async def create_email(ctx, email_address):
+    """
+        Configures the specified email address against user.
+
+        Parameters:
+            ctx: used to access the values passed through the current context
+            email_address: email address specified by the author
+
+        Returns:
+            returns either an error stating a reason for failure or returns a success message
+            indicating that the specified email address has been added.
+
+    """
     author_id = ctx.message.author.id
     fetch_query = 'SELECT author_id FROM email_address WHERE author_id=? and is_active=1'
     cur = db.select_query(fetch_query, (author_id,))
@@ -16,6 +31,18 @@ async def create_email(ctx, email_address):
 
 
 async def update_email(ctx, email_address):
+    """
+        Updates the configured email address in json with the specified one.
+
+        Parameters:
+            ctx: used to access the values passed through the current context
+            email_address: email address specified by the author
+
+        Returns:
+            returns either an error stating a reason for failure or returns a success message
+            indicating that the specified email address has been added.
+
+    """
     author_id = ctx.message.author.id
     fetch_query = 'SELECT author_id FROM email_address WHERE author_id=? and is_active=1'
     cur = db.select_query(fetch_query, (author_id,))
@@ -29,6 +56,17 @@ async def update_email(ctx, email_address):
 
 
 async def view_email(ctx):
+    """
+        Displays the configured email address against user.
+
+        Parameters:
+            ctx: used to access the values passed through the current context
+
+        Returns:
+            returns either an error stating a reason for failure or returns a configured email
+            address.
+
+    """
     author_id = ctx.message.author.id
     fetch_query = 'SELECT email_id FROM email_address WHERE author_id=? and is_active=1'
     cur = db.select_query(fetch_query, (author_id,))
@@ -40,6 +78,17 @@ async def view_email(ctx):
 
 
 async def delete_email(ctx):
+    """
+        Deletes the configured email address against user.
+
+        Parameters:
+            ctx: used to access the values passed through the current context
+
+        Returns:
+            returns either an error stating a reason for failure or returns a success message
+            indicating that the specified email address has been deleted.
+
+    """
     author_id = ctx.message.author.id
     fetch_query = 'SELECT author_id FROM email_address WHERE author_id=? and is_active=1'
     cur = db.select_query(fetch_query, (author_id,))

--- a/src/email_address.py
+++ b/src/email_address.py
@@ -1,0 +1,40 @@
+import db
+
+
+async def create_email(ctx, email_address):
+    author_id = ctx.message.author.id
+    fetch_query = 'SELECT author_id FROM email_address WHERE author_id=? and is_active=1'
+    cur = db.select_query(fetch_query, (author_id,))
+    data = cur.fetchone()
+    if data:
+        await ctx.send('There is already an email address configured for this user. '
+                       'Please update it using update_email command')
+        return
+    insert_query = 'INSERT INTO email_address VALUES (?, ?, ?)'
+    db.mutation_query(insert_query, [author_id, email_address, 1])
+    await ctx.send('Email has been configured successfully!')
+
+
+async def update_email(ctx, email_address):
+    author_id = ctx.message.author.id
+    fetch_query = 'SELECT author_id FROM email_address WHERE author_id=? and is_active=1'
+    cur = db.select_query(fetch_query, (author_id,))
+    data = cur.fetchone()
+    if data:
+        update_query = 'UPDATE email_address SET email_id=? WHERE author_id=? and is_active=?'
+        db.mutation_query(update_query, (email_address, author_id, 1,))
+        await ctx.send('Email address has been updated successfully')
+        return
+    await ctx.send('There is no configured email address')
+
+
+async def view_email(ctx):
+    author_id = ctx.message.author.id
+    fetch_query = 'SELECT email_id FROM email_address WHERE author_id=? and is_active=1'
+    cur = db.select_query(fetch_query, (author_id,))
+    email_address = cur.fetchone()
+    if email_address:
+        await ctx.send('Configured email address : {0}'.format(email_address[0]))
+        return
+    await ctx.send('There is no configured email address')
+

--- a/src/email_address.py
+++ b/src/email_address.py
@@ -38,3 +38,15 @@ async def view_email(ctx):
         return
     await ctx.send('There is no configured email address')
 
+
+async def delete_email(ctx):
+    author_id = ctx.message.author.id
+    fetch_query = 'SELECT author_id FROM email_address WHERE author_id=? and is_active=1'
+    cur = db.select_query(fetch_query, (author_id,))
+    data = cur.fetchone()
+    if data:
+        update_query = 'UPDATE email_address SET is_active=? WHERE author_id=?'
+        db.mutation_query(update_query, (0, author_id,))
+        await ctx.send('Email address has been deleted successfully')
+        return
+    await ctx.send('There is no configured email address')

--- a/src/email_address.py
+++ b/src/email_address.py
@@ -72,7 +72,7 @@ async def view_email(ctx):
     cur = db.select_query(fetch_query, (author_id,))
     email_address = cur.fetchone()
     if email_address:
-        await ctx.send('Configured email address : {0}'.format(email_address[0]))
+        await ctx.send(f'Configured email address : {email_address[0]}')
         return
     await ctx.send('There is no configured email address')
 

--- a/test/test_email_address.py
+++ b/test/test_email_address.py
@@ -1,0 +1,91 @@
+"""
+This file defines tests for email address configuration functions.
+"""
+
+import discord
+from utils import wait_for_msg
+
+
+async def test_create_email_valid(testing_bot, commands_channel):
+    async def wait(content):
+        await wait_for_msg(testing_bot, commands_channel, content)
+
+    await commands_channel.send('!create_email no-reply-test@example.com')
+    await wait('Email has been configured successfully!')
+
+    await commands_channel.send('!remove_email')
+    await wait('Email address has been deleted successfully')
+
+
+async def test_update_email_valid(testing_bot, commands_channel):
+    async def wait(content):
+        await wait_for_msg(testing_bot, commands_channel, content)
+
+    await commands_channel.send('!create_email no-reply-test@example.com')
+    await wait('Email has been configured successfully!')
+
+    await commands_channel.send('!update_email no-reply-test1@example.com')
+    await wait('Email address has been updated successfully')
+
+    await commands_channel.send('!remove_email')
+    await wait('Email address has been deleted successfully')
+
+
+async def test_view_email_valid(testing_bot, commands_channel):
+    async def wait(content):
+        await wait_for_msg(testing_bot, commands_channel, content)
+
+    await commands_channel.send('!create_email no-reply-test@example.com')
+    await wait('Email has been configured successfully!')
+
+    await commands_channel.send('!view_email')
+    await wait('Configured email address : no-reply-test@example.com')
+
+    await commands_channel.send('!remove_email')
+    await wait('Email address has been deleted successfully')
+
+
+async def test_view_email_invalid(testing_bot, commands_channel):
+    async def wait(content):
+        await wait_for_msg(testing_bot, commands_channel, content)
+
+    await commands_channel.send('!view_email')
+    await wait('There is no configured email address')
+
+
+async def test_create_email_invalid(testing_bot, commands_channel):
+    async def wait(content):
+        await wait_for_msg(testing_bot, commands_channel, content)
+
+    await commands_channel.send('!create_email no-reply-test@example.com')
+    await wait('Email has been configured successfully!')
+
+    await commands_channel.send('!create_email no-reply-test@example.com')
+    await wait('There is already an email address configured for this user. '
+               'Please update it using update_email command')
+
+
+async def test_remove_email_invalid(testing_bot, commands_channel):
+    async def wait(content):
+        await wait_for_msg(testing_bot, commands_channel, content)
+
+    await commands_channel.send('!remove_email')
+    await wait('There is no configured email address')
+
+
+async def test(testing_bot, guild_id):
+    commands_channel = discord.utils.get(testing_bot.get_all_channels(), name='q-and-a')
+    guild = testing_bot.get_guild(guild_id)
+    role = discord.utils.get(guild.roles, name="Instructor")
+    member = guild.get_member(testing_bot.user.id)
+    await member.add_roles(role)
+
+    await test_create_email_valid(testing_bot, commands_channel)
+    await test_view_email_valid(testing_bot, commands_channel)
+    await test_update_email_valid(testing_bot, commands_channel)
+
+    await test_remove_email_invalid(testing_bot, commands_channel)
+    await test_view_email_invalid(testing_bot, commands_channel)
+    await test_create_email_invalid(testing_bot, commands_channel)
+
+    await member.remove_roles(role)

--- a/test/tests.py
+++ b/test/tests.py
@@ -11,6 +11,7 @@ import test_calendar
 import test_profanity
 import test_attendance
 import test_help
+import test_email_address
 
 if platform.system() == 'Windows':
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -39,6 +40,8 @@ async def run_tests():
         await test_attendance.test(testing_bot, TEST_GUILD_ID)
         print('testing help\n----------')
         await test_help.test(testing_bot, TEST_GUILD_ID)
+        print('testing email address configuration\n----------')
+        await test_email_address.test(testing_bot, TEST_GUILD_ID)
     except AssertionError as ex:
         print('exception: ', type(ex).__name__ + ':', ex)
         print('--')


### PR DESCRIPTION
This PR contains changes related to email address configuration. Users now will be able to configure their email addresses to receive notifications and file attachments. Tests for the same are defined in the test_email_address file and the following things are taken off.
1.) complies with pylint.
2.) no effect on coverage.